### PR TITLE
Add password generator and import/export utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,55 @@ Watch for changes during development:
 npm run watch
 ```
 
+## Password Generation
+
+Use the `generatePassword` utility to create random passwords. Three presets are available via the `complexity` option:
+
+- `simple`: lowercase letters only.
+- `medium`: adds uppercase and numbers.
+- `strong`: includes symbols as well.
+
+```ts
+import { generatePassword } from './src/utils/passwordGenerator';
+const password = generatePassword({ length: 16, complexity: 'strong' });
+```
+
+## Import / Export
+
+Credentials can be imported from CSV or JSON files and exported in encrypted form.
+
+### CSV format
+
+Each line must contain `id,credential`:
+
+```
+example.com,mySecret
+```
+
+### JSON format
+
+An array of objects:
+
+```json
+[
+  { "id": "example.com", "credential": "mySecret" }
+]
+```
+
+### Export format
+
+Exported data is a JSON string containing encrypted entries as stored internally.
+
+## Usage Steps
+
+1. Prepare your CSV or JSON file in the formats above.
+2. Call `importFromCSV` or `importFromJSON` with your master password and file contents.
+3. Use `exportEncrypted` to produce an encrypted backup of all stored credentials.
+
+## Future Synchronization
+
+Current storage is local only. The exported format is suitable for adding optional synchronisation with external APIs or WebDAV in the future.
+
 ## Installation
 
 1. Run `npm run build` to generate the `dist` folder.

--- a/src/storage/importExport.test.ts
+++ b/src/storage/importExport.test.ts
@@ -1,0 +1,57 @@
+import { importFromCSV, importFromJSON, exportEncrypted } from './importExport';
+import { getCredential } from './secureStore';
+import { webcrypto } from 'crypto';
+
+declare const chrome: any;
+
+Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+
+const store = new Map<string, any>();
+(globalThis as any).chrome = {
+  storage: {
+    local: {
+      async set(obj: Record<string, unknown>) {
+        Object.entries(obj).forEach(([k, v]) => store.set(k, v));
+      },
+      async get(keys: string[] | null) {
+        const result: Record<string, unknown> = {};
+        if (Array.isArray(keys)) {
+          keys.forEach((k) => {
+            result[k] = store.get(k);
+          });
+        } else {
+          store.forEach((v, k) => { result[k] = v; });
+        }
+        return result;
+      },
+      async remove(key: string) {
+        store.delete(key);
+      },
+      async clear() {
+        store.clear();
+      }
+    }
+  }
+};
+
+describe('importExport', () => {
+  beforeEach(async () => {
+    await chrome.storage.local.clear();
+  });
+
+  const master = 'master123';
+
+  it('imports from CSV and JSON and exports encrypted data', async () => {
+    await importFromCSV(master, 'id1,cred1\n');
+    await importFromJSON(master, JSON.stringify([{ id: 'id2', credential: 'cred2' }]));
+
+    expect(await getCredential(master, 'id1')).toBe('cred1');
+    expect(await getCredential(master, 'id2')).toBe('cred2');
+
+    const exported = await exportEncrypted();
+    expect(typeof exported).toBe('string');
+    expect(exported).not.toContain('cred1');
+    const parsed = JSON.parse(exported);
+    expect(parsed).toHaveProperty('id1');
+  });
+});

--- a/src/storage/importExport.ts
+++ b/src/storage/importExport.ts
@@ -1,0 +1,34 @@
+import { saveCredential } from './secureStore';
+
+// chrome typings may not be available in Node environment
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const chrome: any;
+
+export interface CredentialRecord {
+  id: string;
+  credential: string;
+}
+
+export async function importFromCSV(masterPassword: string, csv: string): Promise<void> {
+  const lines = csv.trim().split(/\r?\n/);
+  for (const line of lines) {
+    const [id, credential] = line.split(',');
+    if (id && credential) {
+      await saveCredential(masterPassword, id.trim(), credential.trim());
+    }
+  }
+}
+
+export async function importFromJSON(masterPassword: string, jsonData: string): Promise<void> {
+  const records: CredentialRecord[] = JSON.parse(jsonData);
+  for (const record of records) {
+    if (record.id && record.credential) {
+      await saveCredential(masterPassword, record.id, record.credential);
+    }
+  }
+}
+
+export async function exportEncrypted(): Promise<string> {
+  const all = await chrome.storage.local.get(null);
+  return JSON.stringify(all);
+}

--- a/src/utils/passwordGenerator.test.ts
+++ b/src/utils/passwordGenerator.test.ts
@@ -1,0 +1,21 @@
+import { generatePassword } from './passwordGenerator';
+import { webcrypto } from 'crypto';
+
+Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+
+describe('passwordGenerator', () => {
+  it('generates simple passwords with lowercase only', () => {
+    const pwd = generatePassword({ length: 8, complexity: 'simple' });
+    expect(pwd).toHaveLength(8);
+    expect(pwd).toMatch(/^[a-z]+$/);
+  });
+
+  it('generates strong passwords with diverse characters', () => {
+    const pwd = generatePassword({ length: 16, complexity: 'strong' });
+    expect(pwd).toHaveLength(16);
+    expect(/[A-Z]/.test(pwd)).toBeTruthy();
+    expect(/[a-z]/.test(pwd)).toBeTruthy();
+    expect(/[0-9]/.test(pwd)).toBeTruthy();
+    expect(/[^A-Za-z0-9]/.test(pwd)).toBeTruthy();
+  });
+});

--- a/src/utils/passwordGenerator.ts
+++ b/src/utils/passwordGenerator.ts
@@ -1,0 +1,48 @@
+export type Complexity = 'simple' | 'medium' | 'strong';
+
+export interface PasswordOptions {
+  length?: number;
+  complexity?: Complexity;
+  includeLowercase?: boolean;
+  includeUppercase?: boolean;
+  includeNumbers?: boolean;
+  includeSymbols?: boolean;
+}
+
+const LOWER = 'abcdefghijklmnopqrstuvwxyz';
+const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const NUMBERS = '0123456789';
+const SYMBOLS = '!@#$%^&*()-_=+[]{};:,.<>/?';
+
+const PRESETS: Record<Complexity, Required<Omit<PasswordOptions, 'length' | 'complexity'>>> = {
+  simple: { includeLowercase: true, includeUppercase: false, includeNumbers: false, includeSymbols: false },
+  medium: { includeLowercase: true, includeUppercase: true, includeNumbers: true, includeSymbols: false },
+  strong: { includeLowercase: true, includeUppercase: true, includeNumbers: true, includeSymbols: true }
+};
+
+export function generatePassword(options: PasswordOptions = {}): string {
+  const { length = 12, complexity = 'medium' } = options;
+  const preset = PRESETS[complexity];
+  const settings = {
+    includeLowercase: options.includeLowercase ?? preset.includeLowercase,
+    includeUppercase: options.includeUppercase ?? preset.includeUppercase,
+    includeNumbers: options.includeNumbers ?? preset.includeNumbers,
+    includeSymbols: options.includeSymbols ?? preset.includeSymbols
+  };
+
+  let chars = '';
+  if (settings.includeLowercase) chars += LOWER;
+  if (settings.includeUppercase) chars += UPPER;
+  if (settings.includeNumbers) chars += NUMBERS;
+  if (settings.includeSymbols) chars += SYMBOLS;
+
+  if (!chars) throw new Error('No character sets selected');
+
+  let password = '';
+  const array = new Uint32Array(length);
+  crypto.getRandomValues(array);
+  for (let i = 0; i < length; i++) {
+    password += chars[array[i] % chars.length];
+  }
+  return password;
+}


### PR DESCRIPTION
## Summary
- add configurable password generator with complexity presets
- support importing credentials from CSV or JSON and exporting encrypted data
- document file formats, usage steps, and future sync considerations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a71297cc2483229b6174784455051d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novas Funcionalidades
  - Gerador de senhas com níveis de complexidade (simples, médio, forte) e opções de comprimento e caracteres.
  - Importação de credenciais via CSV e JSON.
  - Exportação de credenciais em formato criptografado para backup.

- Correções/Compatibilidade
  - Melhoria na compatibilidade de armazenamento local para operações de importação/exportação.

- Documentação
  - Guia de geração de senhas com exemplos de uso.
  - Instruções de importação/exportação com formatos CSV/JSON e passos de uso.
  - Nota sobre possível sincronização futura.

- Testes
  - Cobertura automatizada para gerador de senhas e fluxo de importação/exportação.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->