### PR TITLE
fix: load Tailwind via stylesheet

### DIFF
--- a/src/options/index.html
+++ b/src/options/index.html
@@ -3,12 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <title>Options</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.classList.add('dark');
-      }
-    </script>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css"
+    />
   </head>
   <body class="bg-white dark:bg-gray-800">
     <div id="root"></div>

--- a/src/options/main.tsx
+++ b/src/options/main.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import Options from './App';
 
+if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  document.documentElement.classList.add('dark');
+}
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <Options />

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -3,12 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <title>Popup</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.classList.add('dark');
-      }
-    </script>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css"
+    />
   </head>
   <body class="bg-white dark:bg-gray-800">
     <div id="root"></div>

--- a/src/popup/main.tsx
+++ b/src/popup/main.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
+if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  document.documentElement.classList.add('dark');
+}
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- load Tailwind CSS using a stylesheet link instead of a blocked CDN script
- initialize dark mode class from TypeScript entry points

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a6144ad48322889b94922fad16d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migração do Tailwind de script em tempo de execução para folha de estilo estática nas telas de Opções e Popup, reduzindo dependência de JS e melhorando desempenho e estabilidade visual.
- Bug Fixes
  - Aplicação do modo escuro desde o primeiro render com base na preferência do sistema, evitando “flash” de tema incorreto.
- Chores
  - Remoção de scripts inline de inicialização de tema; comportamento de dark mode agora centralizado antes do boot da aplicação.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->