### PR TITLE
feat: add master password management

### DIFF
--- a/src/storage/secureStore.ts
+++ b/src/storage/secureStore.ts
@@ -17,7 +17,75 @@ function base64ToBuffer(base64: string): Uint8Array {
 
 async function getKeyMaterial(password: string): Promise<CryptoKey> {
   const enc = new TextEncoder();
-  return crypto.subtle.importKey('raw', enc.encode(password), 'PBKDF2', false, ['deriveKey']);
+  return crypto.subtle.importKey('raw', enc.encode(password), 'PBKDF2', false, ['deriveKey', 'deriveBits']);
+}
+
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+async function hashPassword(password: string, salt: Uint8Array, iterations: number): Promise<Uint8Array> {
+  const keyMaterial = await getKeyMaterial(password);
+  const derived = await crypto.subtle.deriveBits(
+    { name: 'PBKDF2', salt: salt as unknown as BufferSource, iterations, hash: 'SHA-256' } as any,
+    keyMaterial,
+    256
+  );
+  return new Uint8Array(derived);
+}
+
+export async function setMasterPassword(password: string): Promise<void> {
+  const salt = new Uint8Array(16);
+  crypto.getRandomValues(salt);
+  const iterations = 200000;
+  const hash = await hashPassword(password, salt, iterations);
+  await chrome.storage.local.set({
+    master: {
+      hash: bufferToBase64(hash),
+      salt: bufferToBase64(salt),
+      iterations
+    }
+  });
+}
+
+export async function isMasterPasswordSet(): Promise<boolean> {
+  const { master } = await chrome.storage.local.get(['master']);
+  return !!master;
+}
+
+export async function verifyMasterPassword(password: string): Promise<boolean> {
+  const { master } = await chrome.storage.local.get(['master']);
+  if (!master) return false;
+  const salt = base64ToBuffer(master.salt);
+  const iterations = master.iterations;
+  const expected = base64ToBuffer(master.hash);
+  const actual = await hashPassword(password, salt, iterations);
+  return timingSafeEqual(expected, actual);
+}
+
+export async function changeMasterPassword(oldPassword: string, newPassword: string): Promise<boolean> {
+  if (!(await verifyMasterPassword(oldPassword))) return false;
+  const all = await chrome.storage.local.get(null);
+  for (const [id, value] of Object.entries(all)) {
+    if (id === 'master' || id === 'vaultIndex' || id === 'categories') continue;
+    if (value && (value as any).ciphertext && (value as any).iv && (value as any).salt) {
+      const plain = await getCredential(oldPassword, id);
+      if (plain !== null) {
+        await saveCredential(newPassword, id, plain);
+      }
+    }
+  }
+  await setMasterPassword(newPassword);
+  return true;
+}
+
+export async function resetVault(): Promise<void> {
+  await chrome.storage.local.clear();
 }
 
 async function deriveKey(password: string, salt: Uint8Array): Promise<CryptoKey> {


### PR DESCRIPTION
## Summary
- derive and store hashed master password with PBKDF2
- add popup flows for password setup, unlock, change and reset
- support master password change and vault reset with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7e83e4ca48322b63f5b3c58c51f9b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novos recursos
  - Fluxo de senha mestra: detectar existência, criar, desbloquear de forma assíncrona e exibir erros de validação.
  - Alterar senha mestra com validação e atualização segura dos dados do cofre.
  - Redefinir cofre, limpando todos os dados e retornando ao estado bloqueado.
  - Carregamento inicial do cofre e categorias ao abrir o app.
  - Novas telas/estados: Criar Senha Mestra, Desbloquear, Cofre, Alterar Senha e Redefinir Cofre.
- Testes
  - Cobertura para criação/verificação da senha mestra, troca com recriptografia e redefinição completa do cofre.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->