### PR TITLE
feat: add secure storage functions with AES-GCM

### DIFF
--- a/src/storage/secureStore.test.ts
+++ b/src/storage/secureStore.test.ts
@@ -2,6 +2,7 @@ import {
   saveCredential,
   getCredential,
   deleteCredential,
+  listCredentials,
   setMasterPassword,
   verifyMasterPassword,
   changeMasterPassword,
@@ -58,6 +59,7 @@ describe('secureStore', () => {
     await saveCredential(master, id, credential);
     const stored = store.get(id);
     expect(stored.ciphertext).not.toContain(credential);
+    expect(stored.tag).toBeDefined();
     const result = await getCredential(master, id);
     expect(result).toBe(credential);
   });
@@ -79,6 +81,14 @@ describe('secureStore', () => {
     await deleteCredential(id);
     const result = await getCredential(master, id);
     expect(result).toBeNull();
+  });
+
+  it('lists stored credential ids', async () => {
+    const master = 'master123';
+    await saveCredential(master, 'id1', 'cred1');
+    await saveCredential(master, 'id2', 'cred2');
+    const list = await listCredentials();
+    expect(list).toEqual(expect.arrayContaining(['id1', 'id2']));
   });
 
   it('creates and verifies master password', async () => {


### PR DESCRIPTION
## Summary
- use AES-GCM with random IV and auth tag for credential storage
- add ability to list stored credentials
- cover encryption, decryption and listing with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7eac1d0908322adeeb47663de7e3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novos recursos
  - Adicionada capacidade de listar os IDs das credenciais armazenadas.

- Correções de bugs
  - Maior confiabilidade ao trocar a senha mestra, evitando processar entradas inválidas que poderiam causar erros.
  - Aprimorada a persistência e recuperação de credenciais com criptografia autenticada, reduzindo riscos de falhas de leitura/descrifração.

- Melhorias
  - Robustez geral do cofre aumentada ao validar dados antes de recriptografar e ao tratar componentes de criptografia de forma mais consistente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->