### PR TITLE
Add password generator and dark theme toggle

### DIFF
--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ThemeToggle from './ThemeToggle';
 
 declare const chrome: any;
 
@@ -23,6 +24,9 @@ export default function Options() {
 
   return (
     <div className="p-4 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+      <div className="flex justify-end mb-2">
+        <ThemeToggle />
+      </div>
       <h1 className="text-xl mb-2">Categories</h1>
       <ul className="mb-2 list-disc list-inside">
         {categories.map((c) => (

--- a/src/options/ThemeToggle.tsx
+++ b/src/options/ThemeToggle.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+
+declare const chrome: any;
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    chrome.storage.local.get(['theme'], (res: any) => {
+      const isDark = res.theme === 'dark';
+      setDark(isDark);
+      document.documentElement.classList.toggle('dark', isDark);
+    });
+  }, []);
+
+  const toggle = () => {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle('dark', next);
+    chrome.storage.local.set({ theme: next ? 'dark' : 'light' });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-pressed={dark}
+      aria-label="toggle dark mode"
+      className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+    >
+      {dark ? 'Light' : 'Dark'}
+    </button>
+  );
+}

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import PasswordGenerator from './PasswordGenerator';
+import ThemeToggle from './ThemeToggle';
 import {
   saveCredential,
   getCredential,
@@ -116,6 +118,9 @@ export default function App() {
 
   return (
     <div className="p-4 w-80 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+      <div className="flex justify-end mb-2">
+        <ThemeToggle />
+      </div>
       {hasMaster === false && !unlocked ? (
         <form onSubmit={createMaster} className="space-y-2">
           <label className="block">
@@ -217,14 +222,17 @@ export default function App() {
               className="w-full p-1 border rounded"
               aria-label="username"
             />
-            <input
-              placeholder="Password"
-              type="password"
-              value={form.password}
-              onChange={(e) => setForm({ ...form, password: e.target.value })}
-              className="w-full p-1 border rounded"
-              aria-label="password"
-            />
+            <div className="flex items-center">
+              <input
+                placeholder="Password"
+                type="password"
+                value={form.password}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+                className="w-full p-1 border rounded flex-1"
+                aria-label="password"
+              />
+              <PasswordGenerator onGenerate={(pwd) => setForm({ ...form, password: pwd })} />
+            </div>
             <div>
               <input
                 placeholder="Category"

--- a/src/popup/PasswordGenerator.tsx
+++ b/src/popup/PasswordGenerator.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface Props {
+  onGenerate: (pwd: string) => void;
+}
+
+export default function PasswordGenerator({ onGenerate }: Props) {
+  const generate = () => {
+    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()_+-={}[]';
+    let pwd = '';
+    for (let i = 0; i < 16; i++) {
+      pwd += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    onGenerate(pwd);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={generate}
+      aria-label="generate password"
+      className="ml-2 px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+    >
+      Generate
+    </button>
+  );
+}

--- a/src/popup/ThemeToggle.tsx
+++ b/src/popup/ThemeToggle.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+
+declare const chrome: any;
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    chrome.storage.local.get(['theme'], (res: any) => {
+      const isDark = res.theme === 'dark';
+      setDark(isDark);
+      document.documentElement.classList.toggle('dark', isDark);
+    });
+  }, []);
+
+  const toggle = () => {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle('dark', next);
+    chrome.storage.local.set({ theme: next ? 'dark' : 'light' });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-pressed={dark}
+      aria-label="toggle dark mode"
+      className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+    >
+      {dark ? 'Light' : 'Dark'}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable password generator for credentials form
- add theme toggle with persistent dark mode in popup and options

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at ... please run npx playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ed99a4788322b91fbd75ac51ac91