### PR TITLE
feat: background worker mediation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
     "default_popup": "src/popup/index.html"
   },
   "options_page": "src/options/index.html",
-  "permissions": ["storage"],
+  "permissions": ["storage", "scripting", "activeTab"],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,1 +1,56 @@
-console.log('background script loaded');
+// Background service worker mediating credential storage and retrieval
+// and relaying messages between extension components.
+/* global chrome */
+
+// Keep track of open ports (e.g., from the popup)
+const ports = new Set();
+
+// Handle long‑lived connections
+chrome.runtime.onConnect.addListener((port) => {
+  ports.add(port);
+  port.onDisconnect.addListener(() => ports.delete(port));
+
+  port.onMessage.addListener((msg) => {
+    if (msg.type === 'popupInit') {
+      port.postMessage({ type: 'ack', message: 'Popup connected' });
+    }
+  });
+});
+
+// Relay credential requests and save events from content scripts
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message.type === 'requestCredentials' && sender.tab?.id !== undefined) {
+    chrome.storage.local.get([message.origin]).then((res) => {
+      const creds = res[message.origin];
+      chrome.tabs.sendMessage(sender.tab.id, {
+        type: 'provideCredentials',
+        authorized: Boolean(creds),
+        credentials: creds,
+      });
+    });
+  }
+
+  if (message.type === 'saveCredentials' && message.origin && message.credentials) {
+    chrome.storage.local.set({ [message.origin]: message.credentials }).then(() => {
+      // Notify any connected popup ports that a credential was saved
+      ports.forEach((p) => p.postMessage({ type: 'credentialsSaved', origin: message.origin }));
+    });
+  }
+});
+
+// Extension lifecycle listeners
+chrome.runtime.onInstalled.addListener((details) => {
+  console.log('Extension installed/updated', details);
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  console.log('Extension started');
+});
+
+// Fired when the service worker is about to shut down
+chrome.runtime.onSuspend?.addListener(() => {
+  console.log('Extension suspended');
+});
+
+export {}; // Ensure this file is treated as a module.
+

--- a/src/popup/main.tsx
+++ b/src/popup/main.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
+// chrome typings may not be available in some environments
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const chrome: any;
+
 if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
   document.documentElement.classList.add('dark');
 }
@@ -9,5 +13,15 @@ if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );
+
+// Establish a port to the background service worker
+const port = chrome.runtime.connect({ name: 'popup' });
+port.postMessage({ type: 'popupInit' });
+
+port.onMessage.addListener((msg: any) => {
+  // eslint-disable-next-line no-console
+  console.log('Background message:', msg);
+});
+


### PR DESCRIPTION
## Summary
- add background service worker to handle credential messages and lifecycle events
- open runtime port from popup to background for messaging
- request minimal permissions in manifest

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7f16df3f0832290c3117eeb82b232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novos Recursos
  - Armazenamento e recuperação de credenciais por site diretamente na extensão.
  - Comunicação em tempo real entre o popup e o processo em segundo plano, permitindo atualizações imediatas após salvar credenciais.

- Refactor
  - Transição para um serviço em segundo plano com melhor gerenciamento do ciclo de vida e conexões persistentes, aumentando a confiabilidade.

- Chores
  - Ampliação das permissões da extensão para incluir acesso à aba ativa e execução de scripts, habilitando as novas capacidades e podendo exibir novas solicitações de permissão ao usuário.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->