### PR TITLE
Add Vite dev/build pipeline with TypeScript bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ Install dependencies:
 npm install
 ```
 
-Build the extension:
+Start a development build that rebuilds on file changes:
+
+```sh
+npm run dev
+```
+
+Build the production extension:
 
 ```sh
 npm run build
-```
-
-Watch for changes during development:
-
-```sh
-npm run watch
 ```
 
 ## Password Generation
@@ -71,7 +71,7 @@ Current storage is local only. The exported format is suitable for adding option
 
 ## Installation
 
-1. Run `npm run build` to generate the `dist` folder.
+1. Run `npm run build` to generate the `dist` folder (includes `manifest.json` and assets from `public/`).
 2. Open `chrome://extensions` in your browser and enable *Developer mode*.
 3. Choose **Load unpacked** and select the generated `dist` directory.
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "Starter extension",
   "background": {
-    "service_worker": "src/background/index.js"
+    "service_worker": "src/background/index.ts"
   },
   "action": {
     "default_popup": "src/popup/index.html"
@@ -20,5 +20,10 @@
   ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
+  },
+  "icons": {
+    "16": "icons/icon.svg",
+    "48": "icons/icon.svg",
+    "128": "icons/icon.svg"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0",
         "@playwright/test": "^1.46.0",
+        "@types/chrome": "^0.1.4",
         "@types/jest": "^30.0.0",
+        "@types/node": "^24.3.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^8.57.0",
@@ -2161,10 +2163,45 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chrome": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.4.tgz",
+      "integrity": "sha512-vfISO7SPppN3OKVUqWujtZ4vux3nhDqKaHYEHgfQuPARHuWJ3jjyc1s13H0ckzEc86/neTkCl1TeW72UK6jYKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "dev": "vite",
     "build": "vite build",
     "watch": "vite build --watch",
     "test": "jest",
@@ -20,7 +21,9 @@
     "@playwright/test": "^1.46.0",
     "eslint": "^8.57.0",
     "@typescript-eslint/parser": "^8.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.0.0"
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@types/chrome": "^0.1.4",
+    "@types/node": "^24.3.0"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.1",

--- a/public/icons/icon.svg
+++ b/public/icons/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="16" fill="#4F46E5"/>
+  <path d="M64 72a8 8 0 100-16 8 8 0 000 16zm28-24h-4v-8a24 24 0 10-48 0v8h-4a8 8 0 00-8 8v44a8 8 0 008 8h56a8 8 0 008-8V56a8 8 0 00-8-8zm-40-8a16 16 0 0132 0v8H52v-8zm40 60H36V56h56v44z" fill="#fff"/>
+</svg>

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,12 +1,12 @@
+/// <reference types="chrome" />
 // Background service worker mediating credential storage and retrieval
 // and relaying messages between extension components.
-/* global chrome */
 
 // Keep track of open ports (e.g., from the popup)
-const ports = new Set();
+const ports = new Set<chrome.runtime.Port>();
 
 // Handle long‑lived connections
-chrome.runtime.onConnect.addListener((port) => {
+chrome.runtime.onConnect.addListener((port: chrome.runtime.Port) => {
   ports.add(port);
   port.onDisconnect.addListener(() => ports.delete(port));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": true,
     "lib": ["ES2020", "DOM"],
     "outDir": "dist",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["chrome", "jest", "node"]
   },
   "include": ["src/**/*", "tests/**/*", "**/*.ts"]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,20 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { crx } from '@crxjs/vite-plugin';
 import manifest from './manifest.json' assert { type: 'json' };
+import { resolve } from 'path';
 
 export default defineConfig({
-  plugins: [react(), crx({ manifest })]
+  plugins: [react(), crx({ manifest })],
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      input: {
+        background: resolve(__dirname, 'src/background/index.ts'),
+        content: resolve(__dirname, 'src/content/autofill.ts'),
+        popup: resolve(__dirname, 'src/popup/index.html'),
+        options: resolve(__dirname, 'src/options/index.html')
+      }
+    }
+  },
+  publicDir: 'public'
 });


### PR DESCRIPTION
## Summary
- add `npm run dev` and `npm run build` scripts
- bundle background, popup, options and content scripts with Vite
- copy manifest.json and public assets into `dist`
- document development and build steps

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7f35eba708322833c57bbcb4aa76e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novos recursos
  - Ícones da extensão adicionados (16, 48, 128), melhorando a aparência no navegador.
- Documentação
  - Atualiza instruções de desenvolvimento (novo comando de desenvolvimento) e instalação, esclarecendo o conteúdo gerado no diretório de distribuição.
- Refatoração
  - Service worker migrado para TypeScript e adoção de tipagens do Chrome, sem alterações de comportamento.
- Chores
  - Novo script de desenvolvimento e configuração de build com múltiplas entradas e diretório público para assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->