### PR TITLE
Use browser base64 APIs in secure store

### DIFF
--- a/src/storage/secureStore.test.ts
+++ b/src/storage/secureStore.test.ts
@@ -16,6 +16,15 @@ declare const chrome: any;
 // Ensure Web Crypto API is available in Jest environment
 Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
 
+Object.defineProperty(globalThis, 'btoa', {
+  value: (data: string) => Buffer.from(data, 'binary').toString('base64'),
+  configurable: true
+});
+Object.defineProperty(globalThis, 'atob', {
+  value: (data: string) => Buffer.from(data, 'base64').toString('binary'),
+  configurable: true
+});
+
 // Simple in-memory mock for chrome.storage.local
 const store = new Map<string, any>();
 (globalThis as any).chrome = {

--- a/src/storage/secureStore.ts
+++ b/src/storage/secureStore.ts
@@ -7,12 +7,11 @@ declare const chrome: any;
 
 function bufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
   const bytes = buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer;
-  return Buffer.from(bytes).toString('base64');
+  return btoa(String.fromCharCode(...bytes));
 }
 
 function base64ToBuffer(base64: string): Uint8Array {
-  const buffer = Buffer.from(base64, 'base64');
-  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
 }
 
 async function getKeyMaterial(password: string): Promise<CryptoKey> {


### PR DESCRIPTION
## Summary
- Replace Node Buffer base64 handling with btoa/atob in secure credential storage
- Polyfill atob/btoa in secure store tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c8c38fbc8322b7eef0f1fa79582c