### PR TITLE
Restrict content script to HTTPS and add manifest test

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   "permissions": ["storage", "scripting", "activeTab"],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://*/*"],
       "js": ["src/content/autofill.ts"],
       "run_at": "document_end"
     }

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+test('content script matches only https URLs', () => {
+  const manifestPath = path.resolve(__dirname, '../manifest.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  expect(manifest.content_scripts[0].matches).toEqual(['https://*/*']);
+});


### PR DESCRIPTION
## Summary
- narrow `content_scripts` match pattern to `https://*/*`
- add Jest test verifying manifest content script pattern

## Testing
- `npm test -- --runInBand`
- `npm run build`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a8ddda37848322b9e52d861af3af75