### PR TITLE
Add password visibility toggle and copy functionality

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
   const [categories, setCategories] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const [form, setForm] = useState({ id: '', username: '', password: '', category: '' });
+  const [showPwd, setShowPwd] = useState(false);
 
   useEffect(() => {
     chrome.storage.local.get(['vaultIndex', 'categories'], (res: any) => {
@@ -221,12 +222,20 @@ export default function App() {
             <div className="flex items-center">
               <input
                 placeholder="Password"
-                type="password"
+                type={showPwd ? 'text' : 'password'}
                 value={form.password}
                 onChange={(e) => setForm({ ...form, password: e.target.value })}
                 className="w-full p-1 border rounded flex-1"
                 aria-label="password"
               />
+              <button
+                type="button"
+                onClick={() => setShowPwd((s) => !s)}
+                aria-label={showPwd ? 'hide password' : 'show password'}
+                className="ml-1 text-sm underline"
+              >
+                {showPwd ? 'Ocultar' : 'Mostrar'}
+              </button>
               <PasswordGenerator onGenerate={(pwd) => setForm({ ...form, password: pwd })} />
             </div>
             <div>

--- a/src/popup/PasswordGenerator.tsx
+++ b/src/popup/PasswordGenerator.tsx
@@ -8,10 +8,18 @@ interface Props {
 export default function PasswordGenerator({ onGenerate }: Props) {
   const [length, setLength] = useState(12);
   const [complexity, setComplexity] = useState<Complexity>('medium');
+  const [generated, setGenerated] = useState('');
 
   const generate = () => {
     const pwd = generatePassword({ length, complexity });
+    setGenerated(pwd);
     onGenerate(pwd);
+  };
+
+  const copy = async () => {
+    if (generated) {
+      await navigator.clipboard.writeText(generated);
+    }
   };
 
   return (
@@ -43,6 +51,19 @@ export default function PasswordGenerator({ onGenerate }: Props) {
       >
         Generate
       </button>
+      {generated && (
+        <>
+          <span className="text-xs font-mono">{generated}</span>
+          <button
+            type="button"
+            onClick={copy}
+            aria-label="copy password"
+            className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+          >
+            Copy
+          </button>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add show/hide toggle for password field in popup
- display generated password with copy button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8eeeb27488322971925ce0e76f9f7