### PR TITLE
Remove private signing key from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ go.work.sum
 # Node
 node_modules/
 dist/
+
+# Extension signing key
+key.pem

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ Build the production extension:
 npm run build
 ```
 
+### Extension signing key
+
+To keep a stable extension ID across builds, generate an RSA key pair and
+include the base64‑encoded public key in `manifest.json` under the `"key"`
+field. The private key (`key.pem`) is required during the build process but
+**must not** be committed to version control.
+
+```
+openssl genrsa -out key.pem 2048
+openssl rsa -in key.pem -pubout -outform DER | openssl base64 -A
+```
+
+The repository's `.gitignore` prevents `key.pem` from being added. Store the
+private key securely and reference it locally when running `npm run build`.
+
 ## Password Generation
 
 Use the `generatePassword` utility to create random passwords. Three presets are available via the `complexity` option:

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 3,
   "name": "Sample Extension",
   "version": "0.1.0",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmrzInBWVfNx6+RQeLHkoiu/fdvCZmnX+Gtj3aUzadKJprcoGIxD+yUI/Srr3alTHzBZGDiZpb0j8uL1E/xYfI5o/hTRGeobgmkCQkIw5AbvO6I+Z5MOpLbTgQF9yxs+8U9KKgNndVAmzo7Ix2U67Q6jNIsAqjSxzrvWdyWVLDLIHjpDad/5+W2SRpnz+QB/WdsQVvJQJnzAuQi3sYJ3z4RXHbiKJavw9ksSDMUKK+4VyFfSfNo/I8jBwO0MH5EndWRV2m3Dm/rWa9A5LeQ/qXnqhUN/HkEvrA4tLFhinrA54FiZrTizmzphxIsbWPKj3tFc2sMUhzNvpsi968KmKhwIDAQAB",
   "description": "Starter extension",
   "background": {
     "service_worker": "src/background/index.ts"

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import manifest from './manifest.json' assert { type: 'json' };
 import { resolve } from 'path';
 
 export default defineConfig({
-  plugins: [react(), crx({ manifest })],
+  plugins: [react(), crx({ manifest, keyFile: resolve(__dirname, 'key.pem') })],
   build: {
     outDir: 'dist',
     rollupOptions: {


### PR DESCRIPTION
## Summary
- ignore private RSA key and stop tracking key.pem
- document generating and using extension signing key securely

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8f1fe993483229b3325a3f86b1fba