### PR TITLE
feat: expand popup width

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -144,7 +144,7 @@ export default function App() {
   const filtered = entries.filter((e) => e.id.toLowerCase().includes(search.toLowerCase()) || e.category.toLowerCase().includes(search.toLowerCase()));
 
   return (
-    <div className="p-4 w-80 bg-gray-50 text-gray-900">
+    <div className="p-4 w-[400px] max-w-full bg-gray-50 text-gray-900">
       {hasMaster === false && !unlocked ? (
         <form onSubmit={createMaster} className="space-y-2">
           <label className="block">


### PR DESCRIPTION
## Summary
- widen popup container to 400px and keep responsive with max-width

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a901522ed08322813892852c5e89ae