### PR TITLE
Move password generator below full-width password field

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -246,24 +246,28 @@ export default function App() {
               className="w-full p-1 border rounded"
               aria-label="username"
             />
-            <div className="flex items-center">
-              <input
-                placeholder="Password"
-                type={showPwd ? 'text' : 'password'}
-                value={form.password}
-                onChange={(e) => setForm({ ...form, password: e.target.value })}
-                className="w-full p-1 border rounded flex-1"
-                aria-label="password"
-              />
-              <button
-                type="button"
-                onClick={() => setShowPwd((s) => !s)}
-                aria-label={showPwd ? 'hide password' : 'show password'}
-                className="ml-1 text-sm underline"
-              >
-                {showPwd ? 'Ocultar' : 'Mostrar'}
-              </button>
-              <PasswordGenerator onGenerate={(pwd) => setForm({ ...form, password: pwd })} />
+            <div className="flex flex-col space-y-1">
+              <div className="flex items-center">
+                <input
+                  placeholder="Password"
+                  type={showPwd ? 'text' : 'password'}
+                  value={form.password}
+                  onChange={(e) => setForm({ ...form, password: e.target.value })}
+                  className="w-full p-1 border rounded flex-1"
+                  aria-label="password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPwd((s) => !s)}
+                  aria-label={showPwd ? 'hide password' : 'show password'}
+                  className="ml-1 text-sm underline"
+                >
+                  {showPwd ? 'Ocultar' : 'Mostrar'}
+                </button>
+              </div>
+              <div>
+                <PasswordGenerator onGenerate={(pwd) => setForm({ ...form, password: pwd })} />
+              </div>
             </div>
             <div>
               <input

--- a/src/popup/PasswordGenerator.tsx
+++ b/src/popup/PasswordGenerator.tsx
@@ -23,7 +23,7 @@ export default function PasswordGenerator({ onGenerate }: Props) {
   };
 
   return (
-    <div className="ml-2 flex items-center space-x-1">
+    <div className="flex items-center space-x-1">
       <input
         type="number"
         min={4}


### PR DESCRIPTION
## Summary
- display the PasswordGenerator beneath the password input so the field can use all available width
- drop unnecessary left margin from PasswordGenerator component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a902182dc48322be3b01a39d8b464c