### PR TITLE
chore: migrate to flat eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,43 +1,39 @@
 import js from "@eslint/js";
-import tsPlugin from "@typescript-eslint/eslint-plugin";
-import tsParser from "@typescript-eslint/parser";
+import tseslint from "typescript-eslint";
 import globals from "globals";
 
 export default [
   {
-    ignores: ["dist"]
+    ignores: ["dist"],
   },
   js.configs.recommended,
+  ...tseslint.configs.recommended,
   {
     files: ["**/*.{ts,tsx,js}"],
     languageOptions: {
-      parser: tsParser,
+      parser: tseslint.parser,
       ecmaVersion: "latest",
       sourceType: "module",
       globals: {
         ...globals.browser,
         ...globals.node,
         BufferSource: "readonly",
-        chrome: "readonly"
-      }
-    },
-    plugins: {
-      "@typescript-eslint": tsPlugin
+        chrome: "readonly",
+      },
     },
     rules: {
-      ...tsPlugin.configs.recommended.rules,
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
     },
     linterOptions: {
-      reportUnusedDisableDirectives: "off"
-    }
+      reportUnusedDisableDirectives: "off",
+    },
   },
   {
     files: ["**/*.test.{ts,tsx,js}"],
     languageOptions: {
       globals: {
-        ...globals.jest
-      }
-    }
-  }
+        ...globals.jest,
+      },
+    },
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,6 @@
         "@types/chrome": "^0.1.4",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.3.0",
-        "@typescript-eslint/eslint-plugin": "^8.40.0",
-        "@typescript-eslint/parser": "^8.40.0",
         "eslint": "^9.0.0",
         "globals": "^16.3.0",
         "jest": "^30.0.0",
@@ -28,7 +26,11 @@
         "tailwindcss": "^4.1.12",
         "ts-jest": "^29.1.1",
         "typescript": "^5.4.5",
+        "typescript-eslint": "^8.40.0",
         "vite": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -7552,6 +7554,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.40.0.tgz",
+      "integrity": "sha512-Xvd2l+ZmFDPEt4oj1QEXzA4A2uUK6opvKu3eGN9aGjB8au02lIVcLyi375w94hHyejTOmzIU77L8ol2sRg9n7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.40.0",
+        "@typescript-eslint/parser": "8.40.0",
+        "@typescript-eslint/typescript-estree": "8.40.0",
+        "@typescript-eslint/utils": "8.40.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "engines": { "node": ">=22" },
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -19,8 +21,6 @@
     "@types/chrome": "^0.1.4",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.3.0",
-    "@typescript-eslint/eslint-plugin": "^8.40.0",
-    "@typescript-eslint/parser": "^8.40.0",
     "eslint": "^9.0.0",
     "jest": "^30.0.0",
     "postcss": "^8.5.6",
@@ -28,7 +28,8 @@
     "ts-jest": "^29.1.1",
     "typescript": "^5.4.5",
     "vite": "^7.0.0",
-    "globals": "^16.3.0"
+    "globals": "^16.3.0",
+    "typescript-eslint": "^8.40.0"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.1",


### PR DESCRIPTION
## Summary
- use new `eslint.config.js` flat config with `typescript-eslint`
- drop legacy ESLint plugin configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a90c6619308322b4c5bc7b7e7f9ef9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Migração da configuração de lint para um conjunto unificado de regras TypeScript, simplificando regras e parser.
  - Ajustes na configuração de testes para reconhecer globais comuns do ambiente de testes.
  - Atualização das dependências de desenvolvimento relacionadas ao lint, removendo redundâncias e adotando um pacote unificado.
  - Sem mudanças funcionais para o usuário final; impacto restrito ao fluxo de desenvolvimento e à qualidade do código.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->