### PR TITLE
feat: polish popup styling with Tailwind transitions

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -144,7 +144,8 @@ export default function App() {
   const filtered = entries.filter((e) => e.id.toLowerCase().includes(search.toLowerCase()) || e.category.toLowerCase().includes(search.toLowerCase()));
 
   return (
-    <div className="p-4 w-[400px] max-w-full bg-gray-100 text-gray-900 rounded-lg shadow-sm transition-shadow hover:shadow">
+    <div className="p-4 w-[360px] max-w-full bg-gray-100 text-gray-900">
+      <div className="rounded-lg bg-white shadow-sm p-4 transition-shadow hover:shadow">
       {hasMaster === false && !unlocked ? (
         <form onSubmit={createMaster} className="space-y-2">
           <label className="block">
@@ -153,13 +154,13 @@ export default function App() {
               type="password"
               value={master}
               onChange={(e) => setMaster(e.target.value)}
-              className="w-full p-1 border rounded bg-gray-100"
+              className="w-full px-2 py-1 border border-gray-300 border-opacity-70 rounded bg-gray-50"
               aria-label="new master password"
             />
           </label>
           <button
             type="submit"
-            className="px-2 py-1 bg-green-500 hover:bg-green-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+            className="px-3 py-1.5 bg-green-500 hover:bg-green-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
           >
             Set Password
           </button>
@@ -172,14 +173,14 @@ export default function App() {
               type="password"
               value={master}
               onChange={(e) => setMaster(e.target.value)}
-              className="w-full p-1 border rounded bg-gray-100"
+              className="w-full px-2 py-1 border border-gray-300 border-opacity-70 rounded bg-gray-50"
               aria-label="master password"
             />
           </label>
           {error && <div className="text-red-500 text-sm">{error}</div>}
           <button
             type="submit"
-            className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+            className="px-3 py-1.5 bg-blue-500 hover:bg-blue-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
           >
             Unlock
           </button>
@@ -207,7 +208,7 @@ export default function App() {
                 placeholder="Current"
                 value={master}
                 onChange={(e) => setMaster(e.target.value)}
-                className="w-full p-1 border rounded bg-gray-100"
+                className="w-full px-2 py-1 border border-gray-300 border-opacity-70 rounded bg-gray-50"
                 aria-label="current master password"
               />
               <input
@@ -215,12 +216,12 @@ export default function App() {
                 placeholder="New"
                 value={newMaster}
                 onChange={(e) => setNewMaster(e.target.value)}
-                className="w-full p-1 border rounded bg-gray-100"
+                className="w-full px-2 py-1 border border-gray-300 border-opacity-70 rounded bg-gray-50"
                 aria-label="new master password"
               />
             <button
               type="submit"
-              className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+              className="px-3 py-1.5 bg-blue-500 hover:bg-blue-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
             >
               Change
             </button>
@@ -233,7 +234,7 @@ export default function App() {
               <input
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                className="w-full p-1 border rounded bg-gray-100"
+                className="w-full px-2 py-1 border border-gray-300 border-opacity-70 rounded bg-gray-50"
                 aria-label="search credentials"
               />
             </label>
@@ -262,14 +263,14 @@ export default function App() {
               placeholder="Service"
               value={form.id}
               onChange={(e) => setForm({ ...form, id: e.target.value })}
-              className="w-full p-1 border rounded bg-gray-100"
+              className="w-full px-2 py-1 border border-gray-300 border-opacity-70 rounded bg-gray-50"
               aria-label="service"
             />
             <input
               placeholder="Username"
               value={form.username}
               onChange={(e) => setForm({ ...form, username: e.target.value })}
-              className="w-full p-1 border rounded bg-gray-100"
+              className="w-full px-2 py-1 border border-gray-300 border-opacity-70 rounded bg-gray-50"
               aria-label="username"
             />
             <div className="flex flex-col space-y-1">
@@ -279,7 +280,7 @@ export default function App() {
                   type={showPwd ? 'text' : 'password'}
                   value={form.password}
                   onChange={(e) => setForm({ ...form, password: e.target.value })}
-                  className="w-full p-1 border rounded bg-gray-100 flex-1"
+                  className="w-full px-2 py-1 border border-gray-300 border-opacity-70 rounded bg-gray-50 flex-1"
                   aria-label="password"
                 />
                 <button
@@ -300,7 +301,7 @@ export default function App() {
                 placeholder="Category"
                 value={form.category}
                 onChange={(e) => setForm({ ...form, category: e.target.value })}
-                className="w-full p-1 border rounded bg-gray-100"
+                className="w-full px-2 py-1 border border-gray-300 border-opacity-70 rounded bg-gray-50"
                 aria-label="category"
                 list="category-list"
               />
@@ -312,13 +313,14 @@ export default function App() {
             </div>
             <button
               type="submit"
-              className="px-2 py-1 bg-green-500 hover:bg-green-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+              className="px-3 py-1.5 bg-green-500 hover:bg-green-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
             >
               Save
             </button>
           </form>
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -144,7 +144,7 @@ export default function App() {
   const filtered = entries.filter((e) => e.id.toLowerCase().includes(search.toLowerCase()) || e.category.toLowerCase().includes(search.toLowerCase()));
 
   return (
-    <div className="p-4 w-[400px] max-w-full bg-white text-gray-900 rounded-lg shadow-md transition-shadow hover:shadow-lg">
+    <div className="p-4 w-[400px] max-w-full bg-gray-100 text-gray-900 rounded-lg shadow-sm transition-shadow hover:shadow">
       {hasMaster === false && !unlocked ? (
         <form onSubmit={createMaster} className="space-y-2">
           <label className="block">
@@ -153,11 +153,16 @@ export default function App() {
               type="password"
               value={master}
               onChange={(e) => setMaster(e.target.value)}
-              className="w-full p-1 border rounded"
+              className="w-full p-1 border rounded bg-gray-100"
               aria-label="new master password"
             />
           </label>
-          <button type="submit" className="px-2 py-1 bg-green-600 text-white rounded">Set Password</button>
+          <button
+            type="submit"
+            className="px-2 py-1 bg-green-500 hover:bg-green-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+          >
+            Set Password
+          </button>
         </form>
       ) : !unlocked ? (
         <form onSubmit={unlock} className="space-y-2">
@@ -167,20 +172,31 @@ export default function App() {
               type="password"
               value={master}
               onChange={(e) => setMaster(e.target.value)}
-              className="w-full p-1 border rounded"
+              className="w-full p-1 border rounded bg-gray-100"
               aria-label="master password"
             />
           </label>
           {error && <div className="text-red-500 text-sm">{error}</div>}
-          <button type="submit" className="px-2 py-1 bg-blue-500 text-white rounded">Unlock</button>
+          <button
+            type="submit"
+            className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+          >
+            Unlock
+          </button>
         </form>
       ) : (
         <div className="space-y-3">
           <div className="flex justify-between">
-            <button onClick={() => setShowChange(!showChange)} className="text-sm underline">
+            <button
+              onClick={() => setShowChange(!showChange)}
+              className="text-sm underline transition-colors hover:brightness-110 focus:ring active:scale-95"
+            >
               {showChange ? 'Cancel' : 'Change Password'}
             </button>
-            <button onClick={resetAll} className="text-sm text-red-600 underline">
+            <button
+              onClick={resetAll}
+              className="text-sm text-red-600 underline transition-colors hover:brightness-110 focus:ring active:scale-95"
+            >
               Reset Vault
             </button>
           </div>
@@ -191,7 +207,7 @@ export default function App() {
                 placeholder="Current"
                 value={master}
                 onChange={(e) => setMaster(e.target.value)}
-                className="w-full p-1 border rounded"
+                className="w-full p-1 border rounded bg-gray-100"
                 aria-label="current master password"
               />
               <input
@@ -199,12 +215,15 @@ export default function App() {
                 placeholder="New"
                 value={newMaster}
                 onChange={(e) => setNewMaster(e.target.value)}
-                className="w-full p-1 border rounded"
+                className="w-full p-1 border rounded bg-gray-100"
                 aria-label="new master password"
               />
-              <button type="submit" className="px-2 py-1 bg-blue-500 text-white rounded">
-                Change
-              </button>
+            <button
+              type="submit"
+              className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+            >
+              Change
+            </button>
               {error && <div className="text-red-500 text-sm">{error}</div>}
             </form>
           )}
@@ -214,7 +233,7 @@ export default function App() {
               <input
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                className="w-full p-1 border rounded"
+                className="w-full p-1 border rounded bg-gray-100"
                 aria-label="search credentials"
               />
             </label>
@@ -222,10 +241,17 @@ export default function App() {
           <ul>
             {filtered.map((e) => (
               <li key={e.id} className="flex justify-between items-center mb-1">
-                <button onClick={() => fillForm(e.id)} className="text-left underline flex-1">
+                <button
+                  onClick={() => fillForm(e.id)}
+                  className="text-left underline flex-1 transition-colors hover:brightness-110 focus:ring active:scale-95"
+                >
                   {e.id} ({e.category})
                 </button>
-                <button onClick={() => remove(e.id)} aria-label={`delete ${e.id}`} className="ml-2 text-red-500">
+                <button
+                  onClick={() => remove(e.id)}
+                  aria-label={`delete ${e.id}`}
+                  className="ml-2 text-red-500 transition-colors hover:brightness-110 focus:ring active:scale-95"
+                >
                   ✕
                 </button>
               </li>
@@ -236,14 +262,14 @@ export default function App() {
               placeholder="Service"
               value={form.id}
               onChange={(e) => setForm({ ...form, id: e.target.value })}
-              className="w-full p-1 border rounded"
+              className="w-full p-1 border rounded bg-gray-100"
               aria-label="service"
             />
             <input
               placeholder="Username"
               value={form.username}
               onChange={(e) => setForm({ ...form, username: e.target.value })}
-              className="w-full p-1 border rounded"
+              className="w-full p-1 border rounded bg-gray-100"
               aria-label="username"
             />
             <div className="flex flex-col space-y-1">
@@ -253,14 +279,14 @@ export default function App() {
                   type={showPwd ? 'text' : 'password'}
                   value={form.password}
                   onChange={(e) => setForm({ ...form, password: e.target.value })}
-                  className="w-full p-1 border rounded flex-1"
+                  className="w-full p-1 border rounded bg-gray-100 flex-1"
                   aria-label="password"
                 />
                 <button
                   type="button"
                   onClick={() => setShowPwd((s) => !s)}
                   aria-label={showPwd ? 'hide password' : 'show password'}
-                  className="ml-1 text-sm underline"
+                  className="ml-1 text-sm underline transition-colors hover:brightness-110 focus:ring active:scale-95"
                 >
                   {showPwd ? 'Ocultar' : 'Mostrar'}
                 </button>
@@ -274,7 +300,7 @@ export default function App() {
                 placeholder="Category"
                 value={form.category}
                 onChange={(e) => setForm({ ...form, category: e.target.value })}
-                className="w-full p-1 border rounded"
+                className="w-full p-1 border rounded bg-gray-100"
                 aria-label="category"
                 list="category-list"
               />
@@ -284,7 +310,12 @@ export default function App() {
                 ))}
               </datalist>
             </div>
-            <button type="submit" className="px-2 py-1 bg-green-600 text-white rounded">Save</button>
+            <button
+              type="submit"
+              className="px-2 py-1 bg-green-500 hover:bg-green-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+            >
+              Save
+            </button>
           </form>
         </div>
       )}

--- a/src/popup/PasswordGenerator.tsx
+++ b/src/popup/PasswordGenerator.tsx
@@ -31,13 +31,13 @@ export default function PasswordGenerator({ onGenerate }: Props) {
           max={64}
           value={length}
           onChange={(e) => setLength(Number(e.target.value))}
-          className="w-16 p-1 border rounded text-sm"
+          className="w-16 p-1 border rounded text-sm bg-gray-100"
           aria-label="password length"
         />
         <select
           value={complexity}
           onChange={(e) => setComplexity(e.target.value as Complexity)}
-          className="flex-1 p-1 border rounded text-sm"
+          className="flex-1 p-1 border rounded text-sm bg-gray-100"
           aria-label="password complexity"
         >
           <option value="simple">Simple</option>
@@ -48,7 +48,7 @@ export default function PasswordGenerator({ onGenerate }: Props) {
           type="button"
           onClick={generate}
           aria-label="generate password"
-          className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+          className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
         >
           Generate
         </button>
@@ -60,7 +60,7 @@ export default function PasswordGenerator({ onGenerate }: Props) {
             type="button"
             onClick={copy}
             aria-label="copy password"
-            className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+            className="px-2 py-1 bg-green-500 hover:bg-green-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
           >
             Copy
           </button>

--- a/src/popup/PasswordGenerator.tsx
+++ b/src/popup/PasswordGenerator.tsx
@@ -31,13 +31,13 @@ export default function PasswordGenerator({ onGenerate }: Props) {
           max={64}
           value={length}
           onChange={(e) => setLength(Number(e.target.value))}
-          className="w-16 p-1 border rounded text-sm bg-gray-100"
+          className="w-20 px-2 py-1 border border-gray-300 border-opacity-70 rounded text-sm bg-gray-50"
           aria-label="password length"
         />
         <select
           value={complexity}
           onChange={(e) => setComplexity(e.target.value as Complexity)}
-          className="flex-1 p-1 border rounded text-sm bg-gray-100"
+          className="flex-1 px-2 py-1 border border-gray-300 border-opacity-70 rounded text-sm bg-gray-50"
           aria-label="password complexity"
         >
           <option value="simple">Simple</option>
@@ -48,7 +48,7 @@ export default function PasswordGenerator({ onGenerate }: Props) {
           type="button"
           onClick={generate}
           aria-label="generate password"
-          className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+          className="px-3 py-1.5 bg-blue-500 hover:bg-blue-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
         >
           Generate
         </button>
@@ -60,7 +60,7 @@ export default function PasswordGenerator({ onGenerate }: Props) {
             type="button"
             onClick={copy}
             aria-label="copy password"
-            className="px-2 py-1 bg-green-500 hover:bg-green-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
+            className="px-3 py-1.5 bg-green-500 hover:bg-green-600 text-white rounded shadow-sm hover:shadow transition-colors hover:brightness-110 focus:ring active:scale-95"
           >
             Copy
           </button>


### PR DESCRIPTION
## Summary
- restyle popup with softer gray background and smoother hover interactions
- enhance form elements with Tailwind transitions and focus rings
- update password generator buttons with blue/green palette and shadows

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a915fec334832299381e3b0c41fd80