### PR TITLE
Infer service info from tab title

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -10,6 +10,7 @@ import {
   resetVault,
   isMasterPasswordSet
 } from '../storage/secureStore';
+import { inferServiceInfo } from '../utils/inferServiceInfo';
 
 declare const chrome: any;
 
@@ -67,6 +68,16 @@ export default function App() {
       });
     }
   }, [unlocked]);
+
+  useEffect(() => {
+    if (unlocked) {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs: any[]) => {
+        const title = tabs[0]?.title || '';
+        const info = inferServiceInfo(title, categories);
+        setForm((prev) => ({ ...prev, id: info.id, category: info.category }));
+      });
+    }
+  }, [unlocked, categories]);
 
   const unlock = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/utils/inferServiceInfo.test.ts
+++ b/src/utils/inferServiceInfo.test.ts
@@ -1,0 +1,48 @@
+import { inferServiceInfo } from './inferServiceInfo';
+
+describe('inferServiceInfo', () => {
+  it('extracts service name and infers streaming category', () => {
+    const result = inferServiceInfo('Netflix - Watch TV Shows Online', ['Streaming', 'Social']);
+    expect(result).toEqual({ id: 'Netflix', category: 'Streaming' });
+  });
+
+  it('infers social category using keywords', () => {
+    const result = inferServiceInfo('Facebook – log in', ['Social', 'Banking']);
+    expect(result.id).toBe('Facebook');
+    expect(result.category).toBe('Social');
+  });
+
+  it('returns empty category when no match is found', () => {
+    const result = inferServiceInfo('Unknown Service', ['Social', 'Banking']);
+    expect(result).toEqual({ id: 'Unknown Service', category: '' });
+  });
+
+  it('infers cloud provider category for AWS and Azure', () => {
+    const aws = inferServiceInfo('Amazon Web Services - Console', ['Cloud Provider', 'Monitoring']);
+    expect(aws).toEqual({ id: 'Amazon Web Services', category: 'Cloud Provider' });
+
+    const azure = inferServiceInfo('Microsoft Azure – Portal', ['Cloud Provider']);
+    expect(azure).toEqual({ id: 'Microsoft Azure', category: 'Cloud Provider' });
+  });
+
+  it('infers monitoring category for Grafana', () => {
+    const result = inferServiceInfo('Grafana - Login', ['Monitoring', 'Database']);
+    expect(result).toEqual({ id: 'Grafana', category: 'Monitoring' });
+  });
+
+  it('infers database category for Percona', () => {
+    const result = inferServiceInfo('Percona Server - Sign In', ['Database', 'Monitoring']);
+    expect(result.id).toBe('Percona Server');
+    expect(result.category).toBe('Database');
+  });
+
+  it('infers security category for Vault', () => {
+    const result = inferServiceInfo('Hashicorp Vault - Sign In', ['Security', 'CI']);
+    expect(result).toEqual({ id: 'Hashicorp Vault', category: 'Security' });
+  });
+
+  it('infers CI category for Jenkins', () => {
+    const result = inferServiceInfo('Jenkins - Dashboard', ['CI', 'Cloud Provider']);
+    expect(result).toEqual({ id: 'Jenkins', category: 'CI' });
+  });
+});

--- a/src/utils/inferServiceInfo.ts
+++ b/src/utils/inferServiceInfo.ts
@@ -1,0 +1,34 @@
+export function inferServiceInfo(title: string, categories: string[]): { id: string; category: string } {
+  const service = title.split(/[-|–]/)[0]?.trim() || '';
+  const lowerTitle = title.toLowerCase();
+
+  const categoryKeywords: Record<string, string[]> = {
+    social: ['facebook', 'twitter', 'instagram', 'linkedin', 'reddit', 'social'],
+    email: ['mail', 'gmail', 'outlook', 'yahoo', 'email'],
+    streaming: ['netflix', 'youtube', 'hulu', 'disney', 'prime video', 'stream', 'streaming'],
+    banking: ['bank', 'finance', 'paypal', 'stripe', 'banking'],
+    shopping: ['amazon', 'ebay', 'shopping'],
+    'cloud provider': [
+      'aws',
+      'amazon web services',
+      'azure',
+      'microsoft azure',
+    ],
+    monitoring: ['grafana'],
+    database: ['percona'],
+    security: ['vault', 'hashicorp vault', 'hashicorp'],
+    ci: ['jenkins'],
+    'ci/cd': ['jenkins'],
+  };
+
+  let matchedCategory = '';
+  for (const cat of categories) {
+    const keywords = categoryKeywords[cat.toLowerCase()] || [cat.toLowerCase()];
+    if (keywords.some((kw) => lowerTitle.includes(kw))) {
+      matchedCategory = cat;
+      break;
+    }
+  }
+
+  return { id: service, category: matchedCategory };
+}


### PR DESCRIPTION
## Summary
- Autofill service ID and category from the active tab's title after unlocking
- Add `inferServiceInfo` utility to extract service name and detect category from keywords, including AWS, Azure, Grafana, Percona, Vault, and Jenkins
- Cover service info inference with expanded unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9261b090483228d04e17a6cb21f9b