### PR TITLE
Handle missing credential categories

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -11,6 +11,7 @@ import {
   isMasterPasswordSet
 } from '../storage/secureStore';
 import { inferServiceInfo } from '../utils/inferServiceInfo';
+import { formatCredential } from '../utils/formatCredential';
 
 declare const chrome: any;
 
@@ -295,7 +296,7 @@ export default function App() {
                       onClick={() => fillForm(e.id)}
                       className="text-left underline flex-1 transition-colors hover:brightness-110 focus:ring active:scale-95"
                     >
-                      {e.id} ({e.category})
+                      {formatCredential(e.id, e.category)}
                     </button>
                     <button
                       onClick={() => copyUsername(e.username, e.id)}

--- a/src/utils/formatCredential.ts
+++ b/src/utils/formatCredential.ts
@@ -1,0 +1,3 @@
+export function formatCredential(id: string, category?: string) {
+  return category ? `${id} (${category})` : id;
+}

--- a/tests/formatCredential.test.ts
+++ b/tests/formatCredential.test.ts
@@ -1,0 +1,5 @@
+import { formatCredential } from '../src/utils/formatCredential';
+
+test('credential without category shows only service name', () => {
+  expect(formatCredential('Service', '')).toBe('Service');
+});


### PR DESCRIPTION
## Summary
- format credential display to omit empty categories
- test credential formatting without category

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a935f58aa08322a0c77177a7c72a7e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novidades
  - Exibição de credenciais agora usa formatação padronizada para compor nome e categoria.
- Correções de bugs
  - Quando a categoria está vazia/ausente, a lista mostra apenas o nome do serviço (sem parênteses vazios).
- Refatoração
  - Introduzida função utilitária para centralizar a formatação de credenciais, reduzindo duplicação.
- Testes
  - Adicionados testes unitários garantindo que credenciais sem categoria exibam somente o nome do serviço.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->