### PR TITLE
Add edit icon for credentials in popup list

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -303,15 +303,6 @@ export default function App() {
                       {formatCredential(e.id, e.category)}
                     </button>
                     <button
-                      onClick={() => {
-                        fillForm(e.id);
-                        setActiveTab('add');
-                      }}
-                      className="ml-2 px-2 py-1 bg-gray-200 rounded hover:bg-gray-300 transition"
-                    >
-                      Editar
-                    </button>
-                    <button
                       onClick={() => copyUsername(e.username, e.id)}
                       className="ml-2 px-2 py-1 bg-gray-200 rounded hover:bg-gray-300 transition"
                     >
@@ -322,6 +313,16 @@ export default function App() {
                       className="ml-2 px-2 py-1 bg-gray-200 rounded hover:bg-gray-300 transition"
                     >
                       {copied === `pass-${e.id}` ? 'Copiado!' : 'Copiar senha'}
+                    </button>
+                    <button
+                      onClick={() => {
+                        fillForm(e.id);
+                        setActiveTab('add');
+                      }}
+                      aria-label={`edit ${e.id}`}
+                      className="ml-2 text-blue-500 transition-colors hover:brightness-110 focus:ring active:scale-95"
+                    >
+                      ✎
                     </button>
                     <button
                       onClick={() => remove(e.id)}


### PR DESCRIPTION
## Summary
- replace text edit button with icon beside delete for each credential

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a938f671188322841a320aa47a2fa5